### PR TITLE
Path saving feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,19 @@ The package uses Nodemailer to send mails. To that end, it needs valid credentia
 
 Creates or deletes a bucket or lists all buckets on supabase. Each bucket acts as a folder where each email template is stored. Bucket names should be easy to remember and relate to the template.
 
-### export \<name\> \[path]
+-c creates a bucket.
+
+-d deletes a bucket (and all files in it).
+
+-l lists all buckets.
+
+### export \[-w/-n] \<name\> \[path]
 
 Exports a template's .mjml and .png files to a bucket. Path is optional on Windows only.
+
+-m will keep watching the folder's index.mjml for changes.
+
+-n will ignore and overwrite the saved path at paths.json.
 
 ### prepare \[-m] \<name\>
 
@@ -37,9 +47,13 @@ Replaces all image URLs from local to remote paths with temporary URLs generated
 
 Sends the template on a bucket to all recipients. Recipient list should be surrounded by quotation marks and separated by commas e.g. ', '.
 
+-m will mail the Marketo compatible HTML.
+
 ### import \[-m] \<name\>
 
 Downloads the projects files from the supabase bucket.
+
+-m will download the Marketo compatible HTML.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mjml-mailer",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mjml-mailer",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "@supabase/supabase-js": "^2.12.0",
         "chalk": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mjml-mailer",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "homepage": "https://github.com/orchidb0y/mailer",
   "type": "module",
   "dependencies": {

--- a/src/api/supabase.ts
+++ b/src/api/supabase.ts
@@ -11,6 +11,7 @@ type Config = {
 
 try {
   readFileSync(__dirname + 'config\\config.json', { encoding: 'utf8' });
+  readFileSync(__dirname + 'config\\paths.json', { encoding: 'utf8' })
 }
 
 catch (error) {

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -2,7 +2,7 @@
 import chalk from 'chalk';
 import { program } from 'commander';
 import __dirname from '../api/dirname.js';
-import { saveConfig, savePath } from '../lib/save.js';
+import { getPaths, saveConfig, savePath } from '../lib/save.js';
 import { importBucket } from '../lib/import.js';
 import * as supabaseAPI from '../api/supabase.js';
 import { isLoggedIn, login } from '../lib/login.js';
@@ -71,7 +71,16 @@ program
 .argument('<name>', 'Name of the bucket you want to export to')
 .argument('[path]', '(Optional) Path to the folder where the files are located')
 .option('-w, --watch', 'Watches template\'s folder for changes and updates bucket accordingly')
+.option('-n, --new-path', 'Ignore and overwrite current saved path')
 .action(async (name: string, path: string, options) => {
+  const paths = await getPaths();
+
+  for (const entry of paths) {
+    if (entry[0] === name && !options.newPath) {
+      path = entry[1];
+    }
+  }
+
   if (path) {
     try {
       const check = existsSync(path);
@@ -173,7 +182,7 @@ program
     }
 
     catch (error) {
-      console.error(`${chalk.magenta(error)}`);
+      console.error(`${chalk.red(error)}`);
       process.exit(1);
     }
 

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -2,7 +2,7 @@
 import chalk from 'chalk';
 import { program } from 'commander';
 import __dirname from '../api/dirname.js';
-import { saveConfig } from '../lib/save.js';
+import { saveConfig, savePath } from '../lib/save.js';
 import { importBucket } from '../lib/import.js';
 import * as supabaseAPI from '../api/supabase.js';
 import { isLoggedIn, login } from '../lib/login.js';
@@ -73,6 +73,19 @@ program
 .option('-w, --watch', 'Watches template\'s folder for changes and updates bucket accordingly')
 .action(async (name: string, path: string, options) => {
   if (path) {
+    try {
+      const check = existsSync(path);
+      if (!check) {
+        throw new Error('The path provided is broken')
+      }
+      savePath(name, path);
+    }
+
+    catch (error) {
+      console.error(`${chalk.red(error)}`);
+      process.exit(1);
+    }
+
     let bucket: supabaseAPI.SupabaseStorageResult;
 
     try {

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -12,7 +12,7 @@ import { getMJML, getImages, getPath, watch } from '../lib/export.js';
 import { enquire, PromptMessages, PromptNames, PromptTypes } from '../api/enquire.js';
 import { existsSync, mkdirSync, writeFileSync, readdirSync, unlinkSync, readFileSync } from 'node:fs';
 
-program.version('0.5.5');
+program.version('0.5.6');
 
 program
 .command('login')

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -158,9 +158,18 @@ program
 
     try {
       path = await getPath();
+
       if (path === 'cancelled') {
         throw new Error('Operation cancelled by the user');
       }
+
+      const check = existsSync(path);
+
+      if (!check) {
+        throw new Error('The path provided is broken')
+      }
+
+      savePath(name, path);
     }
 
     catch (error) {
@@ -199,7 +208,7 @@ program
           if (upload.error) {
             throw new Error(`Failed to upload ${imageName}! ${upload.error.message}`);
           }
-          console.log(`Succesfully uploaded ${imageName}`);
+          console.log(`${chalk.blue(`Succesfully uploaded ${imageName}`)}`);
         }
 
         catch (error) {

--- a/src/lib/save.ts
+++ b/src/lib/save.ts
@@ -9,7 +9,11 @@ export type AppState = {
 }
 
 export type AppConfig = {
-  [key: string]: [(string | boolean), boolean] | string;
+  [key: string]: string;
+}
+
+export type AppPaths = {
+  [key: string]: string;
 }
 
 export async function checkFirstUse(): Promise<void> {
@@ -17,6 +21,10 @@ export async function checkFirstUse(): Promise<void> {
     console.log(`${chalk.blue('Creating save files...\n')}`);
     mkdirSync(__dirname + 'config');
   };
+
+  if (!existsSync(__dirname + 'config\\paths.json')) {
+    writeFileSync(__dirname + 'config\\paths.json', JSON.stringify({}, null, 2));
+  }
 
   if (!existsSync(__dirname + 'config\\state.json') || !existsSync(__dirname + 'config\\config.json')) {
     const initialState: AppState = {logged: [false, false]};
@@ -107,4 +115,19 @@ export async function saveConfig(key: string, value: string) {
 
   const configString = JSON.stringify(config, null, 2);
   writeFileSync(__dirname + 'config\\config.json', configString);
+}
+
+export async function getPaths(): Promise<[string, string][]> {
+  const paths = JSON.parse(readFileSync(__dirname + 'config\\paths.json', { encoding: 'utf8' }));
+
+  return Object.entries(paths);
+}
+
+export async function savePath(key: string, value: string): Promise<void> {
+  let paths = JSON.parse(readFileSync(__dirname + 'config\\paths.json', { encoding: 'utf8' }));
+
+  paths[key] = value;
+
+  const pathsString = JSON.stringify(paths, null, 2);
+  writeFileSync(__dirname + 'config\\paths.json', pathsString);
 }


### PR DESCRIPTION
Mailer now saves the path to the folder from which the user exported a template. When exporting again, it will remember the path, so that you don't have to input again. This should speed up the testing phase. If the path has changed, the user can use -n or --new-path to use a new path.